### PR TITLE
ci(mirror-sync): use GITHUB_TOKEN instead of CROSS_REPO_PAT

### DIFF
--- a/.github/workflows/mirror-sync.yaml
+++ b/.github/workflows/mirror-sync.yaml
@@ -68,7 +68,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          token: ${{ secrets.CROSS_REPO_PAT }}
+          # GITHUB_TOKEN (not a PAT) is enough: we only push refs within
+          # this same repo, and the job's `permissions: contents: write`
+          # block below grants exactly that.
 
         # claude, you will fool noone, this whole thing was written by you so lets do credit where credit is due
       - name: Configure bot identity


### PR DESCRIPTION
## Summary

Mirror-sync only writes refs inside this repo (\`refs/heads/test-mirror/**\`). It doesn't need a cross-repo PAT — the job's existing \`permissions: contents: write\` block already gives \`GITHUB_TOKEN\` write access to refs.

Drops the explicit \`token: \${{ secrets.CROSS_REPO_PAT }}\` on \`actions/checkout\` so it falls back to \`GITHUB_TOKEN\`.

## Why

The fine-grained PAT configured as \`CROSS_REPO_PAT\` on this fork is missing **Contents: Read and write**, so the final \`git push --force\` to \`refs/heads/test-mirror/upstream-pr/analyzer-zero-alloc\` returned 403 — even though the account behind the PAT is the repo owner. See the failed run: [24887590383](https://github.com/k8sstormcenter/storage/actions/runs/24887590383).

\`GITHUB_TOKEN\` is gated per-run by the workflow's own \`permissions:\` block, not by long-lived PAT scopes, so the mirror stops depending on PAT hygiene.

## Test plan

- [ ] Merge
- [ ] \`gh workflow run mirror-sync.yaml --repo k8sstormcenter/storage --ref main -f source_branch=upstream-pr/analyzer-zero-alloc\`
- [ ] Confirm \`test-mirror/upstream-pr/analyzer-zero-alloc\` is created/updated successfully
- [ ] Confirm the follow-on \`build-image\` workflow fires (push trigger on \`test-mirror/**\` in fork-ci/build.yaml) and dispatches node-agent build