### PR TITLE
ci(build): pass checked-out SHA to node-agent trigger, not github.sha

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
       client: ${{ steps.params.outputs.client }}
       platforms: ${{ steps.params.outputs.platforms }}
       build_ref: ${{ steps.params.outputs.build_ref }}
+      build_sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,6 +81,14 @@ jobs:
           # On push, inputs.SOURCE_REF is null, so this falls through to
           # github.ref (the pushed branch).
           ref: ${{ inputs.SOURCE_REF || github.ref }}
+
+      - name: Record checked-out SHA
+        id: sha
+        # The SHA we pass downstream (STORAGE_REF → node-agent) must be
+        # the SHA we just checked out, NOT github.sha (which is main's
+        # tip when the workflow was dispatched --ref main). This is the
+        # single source of truth for "which storage commit was built".
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check for image-affecting code changes
         id: check
@@ -198,7 +207,10 @@ jobs:
           GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
         run: |
           IMAGE_TAG="${{ needs.detect-changes.outputs.image_tag }}"
-          STORAGE_REF="${GITHUB_SHA}"
+          # The SHA of the storage commit we actually built — NOT github.sha
+          # (which is main's tip for workflow_dispatch --ref main). node-agent
+          # uses this value in `go mod edit -replace storage=...@STORAGE_REF`.
+          STORAGE_REF="${{ needs.detect-changes.outputs.build_sha }}"
           # Dispatch node-agent on the same ref shape we just built. If
           # SOURCE_REF was set (building an upstream-pr/** branch), tell
           # node-agent to build its matching upstream-pr/** branch too.


### PR DESCRIPTION
## Summary

Fix a bug in the \`trigger-node-agent\` step of \`build.yaml\` introduced in #14. It was passing \`STORAGE_REF=\${GITHUB_SHA}\` — which, for \`workflow_dispatch --ref main\`, is **main's tip SHA**, not the SHA of the branch we actually checked out via \`SOURCE_REF\`. This silently redirected the node-agent cascade to use storage-main's go.mod (which has syft v1.42.3 / stereoscope v0.1.22 / runtime-spec v1.3.0), breaking node-agent's containerd v1.7.30 compile path.

Records \`git rev-parse HEAD\` after the checkout as a new \`build_sha\` output, and uses that for \`STORAGE_REF\`.

## Reproducer (before the fix)

[Run 24899166336](https://github.com/k8sstormcenter/storage/actions/runs/24899166336) — dispatched with \`SOURCE_REF=upstream-pr/analyzer-zero-alloc\`, tip \`e22cdb83\`. The triggered node-agent run got \`STORAGE_REF=44de041b\` (storage main's tip at the time of the PR #16 merge), not \`e22cdb83\`.

## Diff scope

- Adds one step (\`Record checked-out SHA\`) that runs \`git rev-parse HEAD\` and writes to \`\$GITHUB_OUTPUT\`.
- Adds \`build_sha\` to the \`detect-changes\` job outputs.
- Replaces \`STORAGE_REF=\${GITHUB_SHA}\` with \`STORAGE_REF=\${{ needs.detect-changes.outputs.build_sha }}\`.

Total: +13 / -1 lines, one file.

## Behavioural impact

- **\`workflow_dispatch\` with \`SOURCE_REF\`**: now passes the correct SHA. The regression cascade works.
- **\`workflow_dispatch\` without \`SOURCE_REF\`**: checks out \`github.ref\`, which is also what \`github.sha\` refers to — behaviour unchanged.
- **\`push\` to main / sync/upstream-merge**: \`github.sha\` IS the checked-out SHA — behaviour unchanged.

## Test plan

- [ ] Merge
- [ ] \`gh workflow run build.yaml --repo k8sstormcenter/storage --ref main -f SOURCE_REF=upstream-pr/analyzer-zero-alloc -f IMAGE_TAG=zero-alloc-regression -f build_image=true\`
- [ ] Confirm the triggered node-agent run shows \`STORAGE_REF=<upstream-pr tip>\`, not main's SHA
- [ ] Confirm node-agent builds through to component-tests