### PR TITLE
ci: ubuntu-latest for integration-tests + permissions for failover-tests

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     permissions:
       checks: write
       pull-requests: write
@@ -146,6 +146,9 @@ jobs:
 
   failover-tests:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Two fixes that surfaced when cross-repo Manual Integration Tests runs got auto-triggered after the analyzer-zero-alloc work landed.

1. **`integration-tests` pinned to `ubuntu-large`** — no such runner exists in this org, so every run sat queued until GitHub's 24h timeout cancelled it. (Recent zombies: 24990711511, 24964978568.) Switch to `ubuntu-latest`, matching what the `failover-tests` job already uses. This is the same fix you just landed on `node-agent/benchmark.yaml` (commit `aa2e3ff5`).

2. **`failover-tests` had no `permissions:` block** — the `enricomi/publish-unit-test-result-action` step needs `checks: write` + `pull-requests: write`. Without them it fails, the next step `Fail job if any test failed` is skipped, and the whole job is marked `failure` even when the failover tests themselves passed. Today's run `24990711511` shows this exact pattern: every test step is ✓, only `Publish Unit Test Results` is ✗.

## Test plan

- [ ] Re-dispatch Manual Integration Tests; `integration-tests` now picks up a runner instead of queueing
- [ ] `failover-tests` matrix all show conclusion=success when underlying tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)