### PR TITLE
test(dynamicpathdetector): isolate analyzer per subtest in TestAnalyz…

### DIFF
--- a/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestAnalyzeEndpoints(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
-
 	tests := []struct {
 		name     string
 		input    []types.HTTPEndpoint
@@ -94,18 +92,13 @@ func TestAnalyzeEndpoints(t *testing.T) {
 					Methods:  []string{"POST"},
 				},
 			},
-			// NOTE: the analyzer trie persists across subtests in this
-			// table (analyzer is created outside the t.Run loop), so
-			// /users/\u22ef/posts/\u22ef has already been observed enough times
-			// for the :80 entry's trailing segment to be dynamicized;
-			// the :8770 path is fresh in the trie so it stays concrete.
 			expected: []types.HTTPEndpoint{
 				{
 					Endpoint: ":0/users/123/posts/\u22ef",
 					Methods:  []string{"GET"},
 				},
 				{
-					Endpoint: ":80/users/\u22ef/posts/\u22ef",
+					Endpoint: ":80/users/\u22ef/posts/101",
 					Methods:  []string{"POST"},
 				},
 				{
@@ -175,6 +168,7 @@ func TestAnalyzeEndpoints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
 			result := dynamicpathdetector.AnalyzeEndpoints(&tt.input, analyzer)
 			ja := jsonassert.New(t)
 			for i := range result {


### PR DESCRIPTION
…eEndpoints

The table-driven TestAnalyzeEndpoints shared one PathAnalyzer across all subtests. Because AnalyzeEndpoints mutates the analyzer trie, expected outputs of later subtests were silently coupled to the trie state left by earlier ones — running any case in isolation would have exercised a different state and could mask regressions.

Move the analyzer construction inside the t.Run loop so each subtest starts from a fresh trie. Restore the 'Test with 0 port' expected output to its order-independent shape (the :80 entry stays as :80/users/⋯/posts/101 because no other input reaches the trie's dynamic-collapse threshold within that case).

Addresses CodeRabbit review on #21.

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
