### PR TITLE
ci: add explicit top-level permissions to all workflows (least privilege)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,10 @@ on:
 # vendor/, configuration/, api-rules/, hack/.
 # Non-image files = .github/, tests/, docs/, *.md, .gitignore, Makefile, etc.
 # ---------------------------------------------------------------------------
+# Default to read-only at the workflow level (least privilege per Scorecard / supply-chain hardening).
+# Jobs that need elevated scopes override below.
+permissions: read-all
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -24,6 +24,10 @@ on:
         required: false
         default: ''
 
+# Default to read-only at the workflow level (least privilege per Scorecard / supply-chain hardening).
+# Jobs that need elevated scopes override below.
+permissions: read-all
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only at the workflow level (least privilege per Scorecard / supply-chain hardening).
+# Jobs that need elevated scopes override below.
+permissions: read-all
+
 jobs:
   pr-created:
     permissions:

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/*' ### Ignore running when files under path: .github/workflows/* changed.
   workflow_dispatch:
 
+# Default to read-only at the workflow level (least privilege per Scorecard / supply-chain hardening).
+# Jobs that need elevated scopes override below.
+permissions: read-all
+
 jobs:
   pr-merged:
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/*' ### Ignore running when files under path: .github/workflows/* changed.
   workflow_dispatch:
 
+# Default to read-only at the workflow level (least privilege per Scorecard / supply-chain hardening).
+# Jobs that need elevated scopes override below.
+permissions: read-all
+
 jobs:
   pr-merged:
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Why

GITHUB_TOKEN's default scope grants broad write access to issues / PRs / contents / etc. Every workflow file in this repo is currently using that default. Opting into a top-level `permissions: read-all` scopes the default down to read, then jobs that genuinely need write scopes override locally.

This mirrors the equivalent change already in flight on `k8sstormcenter/node-agent` (PR #39 there).

## What

- Adds `permissions: read-all` at the top of every workflow that was missing one (5 files).
- Existing job-level permissions blocks are **unchanged** — they already grant exactly what those jobs need:
  - `build.yaml`'s `build-and-push-image` (`id-token: write`, `packages: write`)
  - `pr-created.yaml`'s `pr-created` (`pull-requests: write`, `security-events: write`)
  - `pr-merged.yaml` + `publish-image.yaml`'s `pr-merged` (writes via the `kubescape/workflows/incluster-comp-pr-merged` reusable)
  - `manual-integration-tests.yml`'s `integration-tests` + `failover-tests`

`build.yaml`'s `detect-changes` and `trigger-node-agent` jobs need no elevated scopes (the latter dispatches via `secrets.CROSS_REPO_PAT`, not GITHUB_TOKEN), so `read-all` at the top suffices.

## Risk

Low. No-op for any job whose existing permissions are correct (which is all of them). YAML validated: all 5 workflow files parse cleanly with `yaml.safe_load`.

## Test plan

- [ ] CI green on this PR
- [ ] `pr-merged.yaml` + `publish-image.yaml` workflow runs succeed end-to-end after merge (these invoke a reusable workflow that requires write scopes — the existing job-level grants stay in place, so this should be unaffected)